### PR TITLE
Func test util image format

### DIFF
--- a/src/sharpedge/_utils/utility.py
+++ b/src/sharpedge/_utils/utility.py
@@ -10,4 +10,3 @@ class Utility:
         # Check the image format: must be a numpy array
         if not isinstance(img_array, np.ndarray):
             raise TypeError("Image format must be a numpy array.")
-        return True

--- a/src/sharpedge/_utils/utility.py
+++ b/src/sharpedge/_utils/utility.py
@@ -1,19 +1,13 @@
 """
 This module contains utility classes and functions for internal use only.
 """
+import numpy as np
+
+
 class Utility:
     @staticmethod
     def _input_checker(img_array):
-        if "Hankun": # Update the condtion
-            # Rasie error message
-            return False  
-        elif "Jenny": # Update the condtion
-            # Rasie error message
-            return False
-        elif "Archer": # Update the condtion
-            # Rasie error message
-            return False
-        elif "Inder": # Update the condtion
-            return False
+        # Check the image format: must be a numpy array
+        if not isinstance(img_array, np.ndarray):
+            raise TypeError("Image format must be a numpy array.")
         return True
-        

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,75 +1,39 @@
+import pytest
 import numpy as np
 from sharpedge._utils.utility import Utility
 
 
 # Part 1 of the input_checker: image format
 # Expected Test Cases
-def test_valid_2d_numpy_array():
-    # Arrange
-    valid_2d_array = np.array([[1, 2], [3, 4]])
-    # Act
-    result = Utility._input_checker(valid_2d_array)
-    # Assert
-    assert result
-
-
-def test_valid_3d_numpy_array():
-    # Arrange
-    valid_3d_array = np.array([[[1, 2, 3], [4, 5, 6]]])
-    # Act
-    result = Utility._input_checker(valid_3d_array)
-    # Assert
-    assert result
+@pytest.mark.parametrize("valid_array", [
+    np.array([[1, 2], [3, 4]]),
+    np.array([[[1, 2, 3], [4, 5, 6]]])
+])
+def test_valid_image_format(valid_array):
+    assert Utility._input_checker(valid_array)
 
 
 # Edge cases
-def test_edge_case_single_pixel_grayscale():
-    # Arrange
-    single_pixel_grayscale = np.array([[255]])
-    # Act
-    result = Utility._input_checker(single_pixel_grayscale)
-    # Assert
-    assert result
-
-
-def test_edge_case_single_pixel_rgb():
-    # Arrange
-    single_pixel_rgb = np.array([[[255, 0, 0]]])
-    # Act
-    result = Utility._input_checker(single_pixel_rgb)
-    # Assert
-    assert result
+@pytest.mark.parametrize("edge_array", [
+    np.array([[255]]),
+    np.array([[[255, 0, 0]]]),
+    np.array([[1.5, 2.5]]),
+    np.array([[[2.35, 3.45, 4.55]]]),
+    np.array([]),
+    np.array([[]]),
+])
+def test_edge_image_format(edge_array):
+    assert Utility._input_checker(edge_array)
 
 
 # Erroneous Cases
-def test_invalid_type_list():
-    # Arrange
-    invalid_list = [1, 2, 3]
-    # Act
-    try:
-        Utility._input_checker(invalid_list)
-    # Assert
-    except TypeError as e:
-        assert str(e) == "Image format must be a numpy array."
-
-
-def test_invalid_type_string():
-    # Arrange
-    invalid_string = "invalid"
-    # Act
-    try:
-        Utility._input_checker(invalid_string)
-    # Assert
-    except TypeError as e:
-        assert str(e) == "Image format must be a numpy array."
-
-
-def test_invalid_type_int():
-    # Arrange
-    invalid_int = 123
-    # Act
-    try:
-        Utility._input_checker(invalid_int)
-    # Assert
-    except TypeError as e:
-        assert str(e) == "Image format must be a numpy array."
+@pytest.mark.parametrize("invalid_input, expected_error", [
+    ([1, 2, 3], "Image format must be a numpy array."),
+    ("invalid", "Image format must be a numpy array."),
+    (123, "Image format must be a numpy array."),
+    ((1, 2, 3), "Image format must be a numpy array."),
+    (None, "Image format must be a numpy array.")
+])
+def test_erroneous_image_format(invalid_input, expected_error):
+    with pytest.raises(TypeError, match=expected_error):
+        Utility._input_checker(invalid_input)

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,4 +1,78 @@
-from sharpedge._utils import Utility
+import os
+import sys
+import numpy as np
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from src.sharpedge._utils.utility import Utility
 
-result = Utility._input_checker([1]) # call the _input_checker function
-print(result)
+
+# Part 1 of the input_checker: image format
+# Expected Test Cases
+def test_valid_2d_numpy_array():
+    # Arrange
+    valid_2d_array = np.array([[1, 2], [3, 4]])
+    # Act
+    result = Utility._input_checker(valid_2d_array)
+    # Assert
+    assert result
+
+
+def test_valid_3d_numpy_array():
+    # Arrange
+    valid_3d_array = np.array([[[1, 2, 3], [4, 5, 6]]])
+    # Act
+    result = Utility._input_checker(valid_3d_array)
+    # Assert
+    assert result
+
+
+# Edge cases
+def test_edge_case_single_pixel_grayscale():
+    # Arrange
+    single_pixel_grayscale = np.array([[255]])
+    # Act
+    result = Utility._input_checker(single_pixel_grayscale)
+    # Assert
+    assert result
+
+
+def test_edge_case_single_pixel_rgb():
+    # Arrange
+    single_pixel_rgb = np.array([[[255, 0, 0]]])
+    # Act
+    result = Utility._input_checker(single_pixel_rgb)
+    # Assert
+    assert result
+
+
+# Erroneous Cases
+def test_invalid_type_list():
+    # Arrange
+    invalid_list = [1, 2, 3]
+    # Act
+    try:
+        Utility._input_checker(invalid_list)
+    # Assert
+    except TypeError as e:
+        assert str(e) == "Image format must be a numpy array."
+
+
+def test_invalid_type_string():
+    # Arrange
+    invalid_string = "invalid"
+    # Act
+    try:
+        Utility._input_checker(invalid_string)
+    # Assert
+    except TypeError as e:
+        assert str(e) == "Image format must be a numpy array."
+
+
+def test_invalid_type_int():
+    # Arrange
+    invalid_int = 123
+    # Act
+    try:
+        Utility._input_checker(invalid_int)
+    # Assert
+    except TypeError as e:
+        assert str(e) == "Image format must be a numpy array."

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,8 +1,5 @@
-import os
-import sys
 import numpy as np
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from src.sharpedge._utils.utility import Utility
+from sharpedge._utils.utility import Utility
 
 
 # Part 1 of the input_checker: image format


### PR DESCRIPTION
- Add conditions that check if input is a NumPy array in `_input_checker`. Raises TypeError if not.
- Add unit test cases for the image format checks.2 expected cases, 2 edge cases, 3 erroneous cases.

P.S. I found out why pytest isn't working. It has something to do with the `__init__.py` under `src\sharpedge`:
```
__version__ = version("sharpedge")
```
Daniel provided the correct approach today. That is, before `pytest`, run `poetry install` first so that the version could be correctly acquired.