### PR TITLE
Func test color conv

### DIFF
--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -1,7 +1,7 @@
 import numpy as np
 import warnings
 
-def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
+def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
     """
     Convert or manipulate image color channels with flexibility for grayscale and RGB.
 
@@ -24,10 +24,11 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
         (height, width, 3) for RGB images.
     
     mode : str, optional
-        The desired target color scale. This can be either:
+        The desired target color scale. This can one of the three:
+        - `'as-is'`: No conversion needed
         - `'gray'`: Convert the image to grayscale.
         - `'rgb'`: Convert the image to RGB.
-        Default is `'gray'`.
+        Default is `'as-is'`.
         
         If the input image is already in the target mode, a notification will be printed, and the 
         function will return the input image as-is without any conversion.
@@ -46,8 +47,8 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
     ch_extract : list/tuple of int, optional
         A list or tuple of integers representing the indices of the RGB channels to extract. For example:
         - `[0] or (0)`: Extract only the Red channel.
-        - `[1] or (1)`: Extract only the Green channel.
-        - `[2] or (2)`: Extract only the Blue channel.
+        - `[1, 2] or (1, 2)`: Extract the Green and Blue channels.
+        - `[2, 0] or (2, 0)`: Extract the Blue and Red channels.
         
         If `None`, no channel extraction occurs. Default is `None`.
         
@@ -98,8 +99,8 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
     """
 
     # Validate 'mode' input
-    if mode not in ['gray', 'rgb']:
-        raise ValueError("Invalid mode. Mode must be either 'gray' or 'rgb'.")
+    if mode not in ['as-is', 'gray', 'rgb']:
+        raise ValueError("Invalid mode. Mode must be 'as-is', 'gray' or 'rgb'.")
 
     # Handle grayscale mode (2D array) and RGB mode (3D array)
     if mode == 'gray' and len(img.shape) == 2:
@@ -162,7 +163,7 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
             
             # Check for length limit (max length of 3 channels)
             if len(ch_extract) > 2:
-                raise ValueError("ch_extract can contain a maximum of 2 elements. Use ch_swap for 3-element extraction (equivalent to swapping).")
+                raise ValueError("ch_extract can contain a maximum of 2 elements. Use ch_swap for 3-element extraction, swapping equivalent.")
             
             if not all(ch in [0, 1, 2] for ch in ch_extract):
                 raise ValueError("Invalid channel indices. Only 0, 1, or 2 are valid.")

--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -133,7 +133,7 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
             
             # Validate ch_swap: must be a list or tuple of 3 integers, with no duplicates, and must include all 0, 1, 2
             if not isinstance(ch_swap, (list, tuple)):
-                raise TypeError(f"ch_swap must be a list or tuple, got {type(ch_swap)}.")
+                raise TypeError("ch_swap must be a list or tuple.")
             
             if not all(isinstance(ch, int) for ch in ch_swap):
                 raise TypeError("All elements in ch_swap must be integers.")
@@ -143,6 +143,9 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
             
             if len(set(ch_swap)) != 3:
                 raise ValueError("ch_swap must include all channels 0, 1, and 2 exactly once.")
+            
+            if ch_swap == (0, 1, 2) or ch_swap == [0, 1, 2]:
+                warnings.warn("Input is in default channel order. No swap needed.", UserWarning)
 
             # Perform channel swapping
             img = img[..., ch_swap]

--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -1,17 +1,17 @@
 import numpy as np
 import warnings
 
-def modulate_image(img, mode='gray', ch_extract=None, ch_swap=None):
+def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
     """
     Convert or manipulate image color channels with flexibility for grayscale and RGB.
 
     This function allows you to perform various color transformations on an image, including:
     - Converting between grayscale and RGB formats.
-    - Extracting specific RGB channels (e.g., Red, Green, or Blue).
     - Swapping RGB channels to rearrange the color channels.
+    - Extracting specific RGB channels (e.g., Red, Green, or Blue).
     
     It supports both grayscale (2D) and RGB (3D) images. If a grayscale image is provided, 
-    channel extraction or swapping will not be applicable, and a notification will be given.
+    channel swapping or extraction will not be applicable, and a notification will be given.
 
     If the input image is already in the target mode (e.g., 'gray' or 'rgb'), the function will notify
     that no conversion is necessary and return the original image.
@@ -32,17 +32,6 @@ def modulate_image(img, mode='gray', ch_extract=None, ch_swap=None):
         If the input image is already in the target mode, a notification will be printed, and the 
         function will return the input image as-is without any conversion.
         
-    ch_extract : list/tuple of int, optional
-        A list or tuple of integers representing the indices of the RGB channels to extract. For example:
-        - `[0] or (0)`: Extract only the Red channel.
-        - `[1] or (1)`: Extract only the Green channel.
-        - `[2] or (2)`: Extract only the Blue channel.
-        
-        If `None`, no channel extraction occurs. Default is `None`.
-        
-        **Note**: This option is only applicable for RGB images. For grayscale images, extraction 
-        is not possible, and a notification will be displayed.
-
     ch_swap : list/tuple of int, optional
         A list or tuple of integers representing the new order of the RGB channels. The list should contain 
         exactly three elements, each of which is an index corresponding to the RGB channels:
@@ -53,6 +42,17 @@ def modulate_image(img, mode='gray', ch_extract=None, ch_swap=None):
         
         **Note**: This option is only applicable for RGB images. For grayscale images, swapping 
         channels is unnecessary, and a notification will be displayed.
+    
+    ch_extract : list/tuple of int, optional
+        A list or tuple of integers representing the indices of the RGB channels to extract. For example:
+        - `[0] or (0)`: Extract only the Red channel.
+        - `[1] or (1)`: Extract only the Green channel.
+        - `[2] or (2)`: Extract only the Blue channel.
+        
+        If `None`, no channel extraction occurs. Default is `None`.
+        
+        **Note**: This option is only applicable for RGB images. For grayscale images, extraction 
+        is not possible, and a notification will be displayed. 
 
     Returns
     -------
@@ -112,12 +112,12 @@ def modulate_image(img, mode='gray', ch_extract=None, ch_swap=None):
     # Convert grayscale to RGB if requested
     if mode == 'rgb' and len(img.shape) == 2:
         print("Converting grayscale to RGB...")
-        return np.stack([img] * 3, axis=-1)
+        img = np.stack([img] * 3, axis=-1)
 
     # Convert RGB to grayscale if requested
     if mode == 'gray' and len(img.shape) == 3:
         print("Converting RGB to grayscale...")
-        return np.mean(img, axis=-1)
+        img = np.mean(img, axis=-1)
 
     # Validate channel extraction when requested (only for RGB images)
     if ch_extract is not None:

--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -123,10 +123,7 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
     # Convert RGB to grayscale if requested
     if mode == 'gray' and len(img.shape) == 3:
         print("Converting RGB to grayscale...")
-        # use luminosity method
-        img = 0.2989 * img[..., 0] + 0.5870 * img[..., 1] + 0.1140 * img[..., 2]
-        # round to the nearest integer for valid pixel value
-        img = np.round(img).astype(np.uint8)
+        img = np.mean(img, axis=-1)
 
     # Check if the image is grayscale (2D) after conversion
     if len(img.shape) == 2:

--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -119,49 +119,53 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
         print("Converting RGB to grayscale...")
         img = np.mean(img, axis=-1)
 
-    # Validate channel extraction when requested (only for RGB images)
-    if ch_extract is not None:
-        if len(img.shape) == 2:
-            warnings.warn("Grayscale images have no channels to extract.", UserWarning)
-            return img  # No channel extraction for grayscale
-        
-        # Validate ch_extract: should be a list or tuple of 0, 1, or 2, with no duplicates
-        if not isinstance(ch_extract, (list, tuple)):
-            raise TypeError("ch_extract must be a list or tuple.")
-        
-        if not all(isinstance(ch, int) for ch in ch_extract):
-            raise TypeError("All elements in ch_extract must be integers.")
-        
-        if not all(ch in [0, 1, 2] for ch in ch_extract):
-            raise ValueError("Invalid channel indices. Only 0, 1, or 2 are valid.")
-        
-        if len(set(ch_extract)) != len(ch_extract):
-            raise ValueError("ch_extract contains duplicate channel indices.")
-        
-        # Handle channel extraction 
-        return img[..., ch_extract]
+    # Check if the image is grayscale (2D) after conversion
+    if len(img.shape) == 2:
+        if ch_swap is not None or ch_extract is not None:
+            warnings.warn("Grayscale images have no channels to swap or extract.", UserWarning)
+        return img  # Return grayscale image
+    
+    # Proceed with channel manipulations when image is RGB (3D) after conversion
+    if len(img.shape) == 3:
+    
+        # Validate channel swapping when requested
+        if ch_swap is not None:
+            
+            # Validate ch_swap: must be a list or tuple of 3 integers, with no duplicates, and must include all 0, 1, 2
+            if not isinstance(ch_swap, (list, tuple)):
+                raise TypeError(f"ch_swap must be a list or tuple, got {type(ch_swap)}.")
+            
+            if not all(isinstance(ch, int) for ch in ch_swap):
+                raise TypeError("All elements in ch_swap must be integers.")
+            
+            if len(ch_swap) != 3 or not all(ch in [0, 1, 2] for ch in ch_swap):
+                raise ValueError("ch_swap must be three elements of valid RGB channel indices 0, 1, or 2.")
+            
+            if len(set(ch_swap)) != 3:
+                raise ValueError("ch_swap must include all channels 0, 1, and 2 exactly once.")
 
-    # Validate channel swapping when requested (only for RGB images)
-    if ch_swap is not None:
-        if len(img.shape) == 2:
-            warnings.warn("Grayscale images have no channels to swap.", UserWarning)
-            return img  # No channel swapping for grayscale
-        
-        # Validate ch_swap: must be a list or tuple of 3 integers, with no duplicates, and must include all 0, 1, 2
-        if not isinstance(ch_swap, (list, tuple)):
-            raise TypeError(f"ch_swap must be a list or tuple, got {type(ch_swap)}.")
-        
-        if not all(isinstance(ch, int) for ch in ch_swap):
-            raise TypeError("All elements in ch_swap must be integers.")
-        
-        if len(ch_swap) != 3 or not all(ch in [0, 1, 2] for ch in ch_swap):
-            raise ValueError("ch_swap must be three elements of valid RGB channel indices 0, 1, or 2.")
-        
-        if len(set(ch_swap)) != 3:
-            raise ValueError("ch_swap must include all channels 0, 1, and 2 exactly once.")
+            # Perform channel swapping
+            img = img[..., ch_swap]
+    
+        # Validate channel extraction when requested (can be potentially after ch_swap)
+        if ch_extract is not None:
 
-        # Handle channel swapping
-        return img[..., ch_swap]
+            # Validate ch_extract: should be a list or tuple of 0, 1, or 2, with no duplicates
+            if not isinstance(ch_extract, (list, tuple)):
+                raise TypeError("ch_extract must be a list or tuple.")
+            
+            if not all(isinstance(ch, int) for ch in ch_extract):
+                raise TypeError("All elements in ch_extract must be integers.")
+            
+            if not all(ch in [0, 1, 2] for ch in ch_extract):
+                raise ValueError("Invalid channel indices. Only 0, 1, or 2 are valid.")
+            
+            if len(set(ch_extract)) != len(ch_extract):
+                raise ValueError("ch_extract contains duplicate channel indices.")
+            
+            # Perform channel extraction 
+            img = img[..., ch_extract]
+
 
     # If no operation is requested, return the original image
     return img

--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -102,6 +102,11 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
     if mode not in ['as-is', 'gray', 'rgb']:
         raise ValueError("Invalid mode. Mode must be 'as-is', 'gray' or 'rgb'.")
 
+    # Handle 'as-is' and when no optional arguments
+    if mode == 'as-is' and ch_swap is None and ch_extract is None:
+        warnings.warn("Mode is 'as-is' and no channel operations are specified. Return the original image.", UserWarning)
+        return img
+
     # Handle grayscale mode (2D array) and RGB mode (3D array)
     if mode == 'gray' and len(img.shape) == 2:
         warnings.warn("Input is already grayscale. No conversion needed.", UserWarning)
@@ -118,7 +123,10 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
     # Convert RGB to grayscale if requested
     if mode == 'gray' and len(img.shape) == 3:
         print("Converting RGB to grayscale...")
-        img = np.mean(img, axis=-1)
+        # use luminosity method
+        img = 0.2989 * img[..., 0] + 0.5870 * img[..., 1] + 0.1140 * img[..., 2]
+        # round to the nearest integer for valid pixel value
+        img = np.round(img).astype(np.uint8)
 
     # Check if the image is grayscale (2D) after conversion
     if len(img.shape) == 2:
@@ -173,7 +181,7 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
             
             # Handle empty extraction (no extraction)
             if len(ch_extract) == 0:
-                warnings.warn("No channels specified for extraction. Returning the image as-is.", UserWarning)
+                warnings.warn("No channels specified for ch_extract. Return the output image with no extraction.", UserWarning)
                 return img
             
             # Perform channel extraction 

--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -99,7 +99,7 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
 
     # Validate 'mode' input
     if mode not in ['gray', 'rgb']:
-        raise ValueError(f"Invalid mode '{mode}'. Mode must be either 'gray' or 'rgb'.")
+        raise ValueError("Invalid mode. Mode must be either 'gray' or 'rgb'.")
 
     # Handle grayscale mode (2D array) and RGB mode (3D array)
     if mode == 'gray' and len(img.shape) == 2:
@@ -160,11 +160,20 @@ def modulate_image(img, mode='gray', ch_swap=None, ch_extract=None):
             if not all(isinstance(ch, int) for ch in ch_extract):
                 raise TypeError("All elements in ch_extract must be integers.")
             
+            # Check for length limit (max length of 3 channels)
+            if len(ch_extract) > 2:
+                raise ValueError("ch_extract can contain a maximum of 2 elements. Use ch_swap for 3-element extraction (equivalent to swapping).")
+            
             if not all(ch in [0, 1, 2] for ch in ch_extract):
                 raise ValueError("Invalid channel indices. Only 0, 1, or 2 are valid.")
             
             if len(set(ch_extract)) != len(ch_extract):
                 raise ValueError("ch_extract contains duplicate channel indices.")
+            
+            # Handle empty extraction (no extraction)
+            if len(ch_extract) == 0:
+                warnings.warn("No channels specified for extraction. Returning the image as-is.", UserWarning)
+                return img
             
             # Perform channel extraction 
             img = img[..., ch_extract]

--- a/tests/test_modulate_image
+++ b/tests/test_modulate_image
@@ -4,22 +4,26 @@ import warnings
 from sharpedge.modulate_image import modulate_image
 
 @pytest.fixture
-def sample_images():
+def img_rgb():
     # Create sample images for testing
-    img_rgb_5 = np.random.randint(0, 256, (5, 5, 3), dtype=np.uint8)  # RGB image (5x5) with 3 channels
-    img_gray_5 = np.random.randint(0, 256, (5, 5), dtype=np.uint8)  # Grayscale image (5x5)
-    img_rgb_10_5 = np.random.randint(0, 256, (10, 5, 3), dtype=np.uint8)  # RGB image (10x5) with 3 channels
-    img_gray_10_5 = np.random.randint(0, 256, (10, 5), dtype=np.uint8)  # Grayscale image (10x5)
-    return img_rgb_5, img_gray_5, img_rgb_10_5, img_gray_10_5
+    img_rgb = np.random.randint(0, 256, (5, 5, 3), dtype=np.uint8)  # RGB image (5x5) with 3 channels
+    return img_rgb
+
+@pytest.fixture
+def img_gray():
+    # Create sample images for testing
+    img_gray = np.random.randint(0, 256, (5, 5), dtype=np.uint8)  # Grayscale image (5x5)
+    return img_gray
 
 # Expected Test Cases:
 @pytest.mark.parametrize(
     "test_img, mode, ch_swap, ch_extract, expected_shape",
     [
-        (img_gray_10_5, 'rgb', None, None, (10, 5, 3)),  # Grayscale image (10x5) to RGB
-        (img_rgb_10_5, 'gray', None, None, (10, 5)),  # RGB image (10x5) to grayscale
-        (img_gray_5, 'rgb', [2, 1, 0], None, (5, 5, 3)),  # RGB image (5x5) to RGB
-        (img_rgb_5, 'gray', (5, 5)),  # Grayscale image (5x5) to grayscale
+        (img_gray, 'rgb', None, None, (5, 5, 3)),  # Grayscale image (10x5) to RGB
+        (img_rgb, 'gray', None, None, (5, 5)),  # RGB image (10x5) to grayscale
+        (img_gray, 'rgb', [2, 1, 0], None, (5, 5, 3)),  # RGB swap Red and Blue channels
+        (img_rgb, 'rgb', None, [0, 1] (5, 5, 2)),  # RGB extract Red and Green channels
+        (img_gray, 'rgb', [2, 1, 0], [0, 1], (5, 5, 2)),  # RGB swap and extract combined
     ]
 )
 def test_valid_inputs(test_img, mode, expected_shape):

--- a/tests/test_modulate_image
+++ b/tests/test_modulate_image
@@ -1,0 +1,80 @@
+import pytest
+import numpy as np
+import warnings
+from sharpedge.modulate_image import modulate_image
+
+@pytest.fixture
+def sample_images():
+    # Create sample images for testing
+    img_rgb_5 = np.random.randint(0, 256, (5, 5, 3), dtype=np.uint8)  # RGB image (5x5) with 3 channels
+    img_gray_5 = np.random.randint(0, 256, (5, 5), dtype=np.uint8)  # Grayscale image (5x5)
+    img_rgb_10_5 = np.random.randint(0, 256, (10, 5, 3), dtype=np.uint8)  # RGB image (10x5) with 3 channels
+    img_gray_10_5 = np.random.randint(0, 256, (10, 5), dtype=np.uint8)  # Grayscale image (10x5)
+    return img_rgb_5, img_gray_5, img_rgb_10_5, img_gray_10_5
+
+# Expected Test Cases:
+@pytest.mark.parametrize(
+    "test_img, mode, ch_swap, ch_extract, expected_shape",
+    [
+        (img_gray_10_5, 'rgb', None, None, (10, 5, 3)),  # Grayscale image (10x5) to RGB
+        (img_rgb_10_5, 'gray', None, None, (10, 5)),  # RGB image (10x5) to grayscale
+        (img_gray_5, 'rgb', [2, 1, 0], None, (5, 5, 3)),  # RGB image (5x5) to RGB
+        (img_rgb_5, 'gray', (5, 5)),  # Grayscale image (5x5) to grayscale
+    ]
+)
+def test_valid_inputs(test_img, mode, expected_shape):
+    result = modulate_image(test_img, mode=mode)
+    assert result.shape == expected_shape
+
+# Edge Cases:
+@pytest.mark.parametrize(
+    "img, mode, expected_warning",
+    [
+        ('rgb', 'rgb', "Input is already RGB. No conversion needed."),  # RGB to RGB (no change)
+        ('gray', 'gray', "Input is already grayscale. No conversion needed.")  # Grayscale to Grayscale (no change)
+    ]
+)
+def test_edge_cases(sample_images, img, mode, expected_warning):
+    img_rgb, img_gray = sample_images
+    
+    # Select the image based on the mode
+    if img == 'rgb':
+        test_img = img_rgb
+    else:
+        test_img = img_gray
+
+    with pytest.warns(UserWarning, match=expected_warning):
+        result = modulate_image(test_img, mode=mode)
+
+# Error Cases: These are the cases where the function should raise errors
+@pytest.mark.parametrize(
+    "img, mode, ch_extract, ch_swap, expected_exception",
+    [
+        # Invalid mode
+        ('rgb', 'invalid_mode', None, None, ValueError),  # Invalid mode value
+        # Invalid ch_extract
+        ('rgb', 'rgb', [3], None, ValueError),  # Invalid channel index in ch_extract
+        ('rgb', 'rgb', 'wrong_type', None, TypeError),  # ch_extract should be a list/tuple
+        # Invalid ch_swap
+        ('rgb', 'rgb', None, [0, 1], ValueError),  # Invalid ch_swap (not enough elements)
+        ('rgb', 'rgb', None, [0, 1, 3], ValueError),  # Invalid ch_swap (index out of range)
+        ('rgb', 'rgb', None, [0, 1, 1], ValueError),  # Invalid ch_swap (duplicate indices)
+        ('gray', 'rgb', None, [0, 1, 2], UserWarning),  # Trying to swap channels on grayscale
+    ]
+)
+def test_error_cases(sample_images, img, mode, ch_extract, ch_swap, expected_exception):
+    img_rgb, img_gray = sample_images
+
+    # Select the image based on the mode
+    if img == 'rgb':
+        test_img = img_rgb
+    else:
+        test_img = img_gray
+
+    if ch_extract is not None:
+        with pytest.raises(expected_exception):
+            modulate_image(test_img, mode=mode, ch_extract=ch_extract, ch_swap=ch_swap)
+    else:
+        with pytest.raises(expected_exception):
+            modulate_image(test_img, mode=mode, ch_extract=ch_extract, ch_swap=ch_swap)
+

--- a/tests/test_modulate_image.py
+++ b/tests/test_modulate_image.py
@@ -4,31 +4,47 @@ import warnings
 from sharpedge.modulate_image import modulate_image
 
 @pytest.fixture
-def img_rgb():
-    # Create sample images for testing
-    img_rgb = np.random.randint(0, 256, (5, 5, 3), dtype=np.uint8)  # RGB image (5x5) with 3 channels
-    return img_rgb
-
-@pytest.fixture
-def img_gray():
-    # Create sample images for testing
-    img_gray = np.random.randint(0, 256, (5, 5), dtype=np.uint8)  # Grayscale image (5x5)
-    return img_gray
+def img_dict():
+    """
+    Fixture that returns a dictionary with input and expected output arrays for testing.
+    """
+    # Dictionary of inputs and expected outputs
+    img_dict = {
+        "img_rgb": np.full((5, 5, 3), [100, 150, 200], dtype=np.uint8),  # Creates a 5x5 RGB image with same values,
+        "img_gray": np.full((5, 5), 100, dtype=np.uint8),  # Creates a 5x5 grayscale image with value 100 for all pixels
+        "expected_rgb_to_gray": np.full((5, 5), 150, dtype=np.uint8),  # Averaging RGB values
+        "expected_gray_to_rgb": np.full((5, 5, 3), [100, 100, 100], dtype=np.uint8),  # Grayscale to RGB conversion
+        "expected_rgb_swap": np.full((5, 5, 3), [200, 150, 100], dtype=np.uint8),  # Swap Red and Blue channels
+        "expected_rgb_extract": np.full((5, 5, 2), [100, 150], dtype=np.uint8),  # Extract Red and Green channels
+        "expected_rgb_swap_extract": np.full((5, 5, 2), [200, 150], dtype=np.uint8),  # Swap and Extract Red and Green
+    }
+    return img_dict
 
 # Expected Test Cases:
 @pytest.mark.parametrize(
-    "test_img, mode, ch_swap, ch_extract, expected_shape",
+    "test_img, mode, ch_swap, ch_extract, expected_output",
     [
-        (img_gray, 'rgb', None, None, (5, 5, 3)),  # Grayscale image (10x5) to RGB
-        (img_rgb, 'gray', None, None, (5, 5)),  # RGB image (10x5) to grayscale
-        (img_gray, 'rgb', [2, 1, 0], None, (5, 5, 3)),  # RGB swap Red and Blue channels
-        (img_rgb, 'rgb', None, [0, 1] (5, 5, 2)),  # RGB extract Red and Green channels
-        (img_gray, 'rgb', [2, 1, 0], [0, 1], (5, 5, 2)),  # RGB swap and extract combined
+        ("img_gray", 'rgb', None, None, "expected_gray_to_rgb"),  # Grayscale image to RGB
+        ("img_rgb", 'gray', None, None, "expected_rgb_to_gray"),  # RGB image to grayscale
+        ("img_gray", 'rgb', [2, 1, 0], None, "expected_rgb_swap"),  # Swap Red and Blue channels
+        ("img_rgb", 'rgb', None, [0, 1], "expected_rgb_extract"),  # Extract Red and Green channels
+        ("img_gray", 'rgb', [2, 1, 0], [0, 1], "expected_rgb_swap_extract"),  # Swap and Extract Red and Green channels
     ]
 )
-def test_valid_inputs(test_img, mode, expected_shape):
-    result = modulate_image(test_img, mode=mode)
-    assert result.shape == expected_shape
+def test_valid_inputs(img_dict, test_img, mode, ch_swap, ch_extract, expected_output):
+    """
+    Test the modulate_image function using various modes and transformations.
+    """
+    # Retrieve the actual image and expected output from the fixture
+    test_img_array = img_dict[test_img]
+    expected_output_array = img_dict[expected_output]
+
+    # Run the function
+    result = modulate_image(test_img_array, mode=mode, ch_swap=ch_swap, ch_extract=ch_extract)
+    
+    # Check that the result matches the expected output exactly
+    np.testing.assert_array_equal(result, expected_output_array)
+
 
 # Edge Cases:
 @pytest.mark.parametrize(

--- a/tests/test_modulate_image.py
+++ b/tests/test_modulate_image.py
@@ -46,25 +46,48 @@ def test_valid_inputs(img_dict, test_img, mode, ch_swap, ch_extract, expected_ou
     np.testing.assert_array_equal(result, expected_output_array)
 
 
-# Edge Cases:
+# Edge Cases:**Test for Warnings**
+@pytest.fixture
+def warn_msg():
+    """
+    Provides the common warnings for the edge test cases.
+    """
+    COMMON_WARN = {
+        "user_warn_rgb": "Input is already RGB. No conversion needed.",
+        "user_warn_gray": "Input is already grayscale. No conversion needed.",
+        "user_warn_swap_extr": "Grayscale images have no channels to swap or extract."
+    }
+    return COMMON_WARN
+
 @pytest.mark.parametrize(
-    "img, mode, expected_warning",
+    "img, mode, ch_swap, ch_extract, expected_output, expected_warning, msg_key",
     [
-        ('rgb', 'rgb', "Input is already RGB. No conversion needed."),  # RGB to RGB (no change)
-        ('gray', 'gray', "Input is already grayscale. No conversion needed.")  # Grayscale to Grayscale (no change)
+        # Scenario 1: No change needed when input and conversion mode the same
+        ("img_rgb", 'rgb', None, None, "img_rgb", UserWarning, "user_warn_rgb"),  # RGB to RGB 
+        ("img_gray", 'gray', None, None, "img_gray", UserWarning,"user_warn_gray" )  # Grayscale to Grayscale 
+
+        # Scenario 2: Grayscale not qualified for color swap or extraction
+        ("img_gray", 'gray', [2, 1, 0], None, "img_gray", UserWarning, "user_warn_swap_extr")
+        ("img_gray", 'gray', None, [0, 1], "img_gray", UserWarning, "user_warn_swap_extr")
+
     ]
 )
-def test_edge_cases(sample_images, img, mode, expected_warning):
-    img_rgb, img_gray = sample_images
-    
-    # Select the image based on the mode
-    if img == 'rgb':
-        test_img = img_rgb
-    else:
-        test_img = img_gray
+def test_edge_cases(image_data, test_img, mode, ch_swap, ch_extract, expected_output, expected_warning, msg):
+    """
+    Test edge cases where no transformation should occur or where warnings should be raised.
+    """
+    # Retrieve the actual image and expected output from the fixture dictionary
+    test_img_array = image_data[test_img]  # Access input image array
+    expected_output_array = image_data[expected_output]  # Access expected output array
+    msg = COMMON_WARN[msg_key]  # Access expected warning msg
 
-    with pytest.warns(UserWarning, match=expected_warning):
-        result = modulate_image(test_img, mode=mode)
+    # Use pytest's `warns` to check that a warning is raised during the function call
+    with pytest.warns(expected_warning, match=msg):
+        result = modulate_image(test_img_array, mode=mode, ch_swap=ch_swap, ch_extract=ch_extract)
+    
+    # Check that the result matches the expected output exactly
+    np.testing.assert_array_equal(result, expected_output_array)
+
 
 # Error Cases: These are the cases where the function should raise errors
 @pytest.mark.parametrize(

--- a/tests/test_modulate_image.py
+++ b/tests/test_modulate_image.py
@@ -12,7 +12,7 @@ def img_dict():
     img_dict = {
         "img_rgb": np.full((5, 5, 3), [100, 150, 200], dtype=np.uint8),  # Creates a 5x5 RGB image with same values,
         "img_gray": np.full((5, 5), 100, dtype=np.uint8),  # Creates a 5x5 grayscale image with value 100 for all pixels
-        "expected_rgb_to_gray": np.full((5, 5), 141, dtype=np.uint8),  # Averaging RGB values
+        "expected_rgb_to_gray": np.full((5, 5), 150, dtype=np.uint8),  # Averaging RGB values
         "expected_gray_to_rgb": np.full((5, 5, 3), [100, 100, 100], dtype=np.uint8),  # Grayscale to RGB conversion
         "expected_rgb_swap": np.full((5, 5, 3), [200, 150, 100], dtype=np.uint8),  # Swap Red and Blue channels
         "expected_rgb_extract": np.full((5, 5, 2), [100, 150], dtype=np.uint8),  # Extract Red and Green channels


### PR DESCRIPTION
- function code for `modulate_image`
- unit test cases for `modulate_image`: 33 cases in total. Run past `pytest`

Will need to check upon pytest-cov upon merging to main.

Also note, as our utility function needs some final touches, I have not called on _input_checker in my individual function as of now, but will be added upon review of individual function. Right now, it assumes all input img_array meet standards and omission of _input_checker does not impact review in any way. 