### PR TITLE
Fix the NoSuchKernel exception on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,8 @@ build:
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --all-groups
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
+      - python -m ipykernel install --user --name="SharpEdge"
       
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ build:
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --all-groups
       
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
Adjust the `.readthedocs.yml` file so that Read the Docs can successfully render and serve our documentations.