### PR TITLE
Fix import error with the scikit-image package

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ build:
       - pip install poetry
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
-      - pip install scikit-image
+      - $VIRTUAL_ENV/bin/pip install scikit-image
       - python -m ipykernel install --user --name="SharpEdge"
       
 # Build documentation in the "docs/" directory with Sphinx

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,7 @@ build:
       - pip install poetry
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
+      - pip install scikit-image
       - python -m ipykernel install --user --name="SharpEdge"
       
 # Build documentation in the "docs/" directory with Sphinx

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,9 @@ build:
       - pip install poetry
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
-      - $VIRTUAL_ENV/bin/pip install scikit-image
+      - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+      - python get-pip.py  # Install pip in the virtual environment
+      - $VIRTUAL_ENV/bin/pip install scikit-image  # Install scikit-image using the newly installed pip
       - python -m ipykernel install --user --name="SharpEdge"
       
 # Build documentation in the "docs/" directory with Sphinx

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,9 +17,9 @@ build:
       - pip install poetry
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
-      - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-      - python get-pip.py  # Install pip in the virtual environment
-      - $VIRTUAL_ENV/bin/pip install scikit-image  # Install scikit-image using the newly installed pip
+      - python -m ensurepip --upgrade
+      - python -m pip install --upgrade pip
+      - python -m pip install scikit-image  # Install scikit-image
       - python -m ipykernel install --user --name="SharpEdge"
       
 # Build documentation in the "docs/" directory with Sphinx


### PR DESCRIPTION
Finally! After several trials, I successfully installed poetry via pip instead of poetry by adding some lines to our `.readthedocs.yml` file:

```
    post_install:
      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
      - python -m ensurepip --upgrade
      - python -m pip install --upgrade pip
      - python -m pip install scikit-image  # Install scikit-image
      - python -m ipykernel install --user --name="SharpEdge"
```