### PR TITLE
build: updated ci-cd.yml for RELEASE_TOKEN

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,12 +60,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Use Python Semantic Release to prepare release
         id: release
         uses: python-semantic-release/python-semantic-release@v8.3.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -92,4 +93,4 @@ jobs:
         uses: python-semantic-release/upload-to-gh-release@main
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Hi team,

ci-cd.yml file has been updated for automatic integration and deployment. All the four tokens have also been set up in secrets.

I am requesting this to be pushed to main for testing. Do note for this round run of ci, we are getting an error because we have an error in building documentation, see below, anyone has any insights to what this might be? The funny thing is, when I tried `make html` in `docs`, none of these errors show up, only the warnings that we expect. 

![image](https://github.com/user-attachments/assets/59049689-0a43-440a-bd64-1668b083be5f)
