### PR TITLE
fix: Feedback addressed by Archer - Milestone 1 feedback on Software package project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ To harness the image processing magic of SharpEdge, follow these steps:
 1. Import the required functions from the package:
 
     ```python
-    from sharpedge.reposition_image import reposition_image
-    from sharpedge.frame_image import frame_image
-    from sharpedge.modulate_image import modulate_image
-    from sharpedge.pooling_image import pooling_image
-    from sharpedge.pca_compression import pca_compression
-    from sharpedge.seam_carving import seam_carve
+    from sharpedge import reposition_image
+    from sharpedge import frame_image
+    from sharpedge import modulate_image
+    from sharpedge import pooling_image
+    from sharpedge import pca_compression
+    from sharpedge import seam_carve
     ```
 
 2. (Optional) Load your image as a NumPy array.

--- a/src/sharpedge/__init__.py
+++ b/src/sharpedge/__init__.py
@@ -1,3 +1,10 @@
 # read version from installed package
 from importlib.metadata import version
 __version__ = version("sharpedge")
+
+from sharpedge.reposition_image import reposition_image
+from sharpedge.frame_image import frame_image
+from sharpedge.modulate_image import modulate_image
+from sharpedge.pooling_image import pooling_image
+from sharpedge.pca_compression import pca_compression
+from sharpedge.seam_carving import seam_carve

--- a/src/sharpedge/modulate_image.py
+++ b/src/sharpedge/modulate_image.py
@@ -19,6 +19,7 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
 
     Parameters
     ----------
+    
     img : numpy.ndarray
         Input image array. This can be either a 2D numpy array (grayscale image) or a 3D numpy array 
         (RGB image). The dimensions of the image should be (height, width) for grayscale or 
@@ -58,6 +59,7 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
 
     Returns
     -------
+    
     numpy.ndarray
         A numpy array representing the manipulated image. The output could be:
         - A grayscale image (2D array).
@@ -67,12 +69,14 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
 
     Raises
     ------
+    
     ValueError
         If the input image is not in grayscale or RGB format, or if any invalid channel indices are 
         provided for extraction or swapping.
 
     Notes
     ------
+    
     - Grayscale images (2D arrays) do not have multiple color channels, so channel extraction or 
       swapping will not be possible. These operations will be skipped with a corresponding notification.
     - If no operations are specified (i.e., no conversion or channel manipulation), the function will
@@ -82,6 +86,7 @@ def modulate_image(img, mode='as-is', ch_swap=None, ch_extract=None):
       
     Examples
     --------
+    
     # Convert an RGB image to grayscale
     grayscale_image = modulate_image(rgb_image, mode='gray')
 

--- a/tests/test_frame_image.py
+++ b/tests/test_frame_image.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from sharpedge.frame_image import frame_image  
+from sharpedge import frame_image  
 
 # Expected Test Cases:
 @pytest.mark.parametrize("valid_img, h_border, w_border, inside, color, expected_size", [

--- a/tests/test_modulate_image.py
+++ b/tests/test_modulate_image.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import warnings
-from sharpedge.modulate_image import modulate_image
+from sharpedge import modulate_image
 
 @pytest.fixture
 def img_dict():

--- a/tests/test_pca_compression.py
+++ b/tests/test_pca_compression.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from sharpedge.pca_compression import pca_compression
+from sharpedge import pca_compression
 
 # Expected Test Cases
 @pytest.mark.parametrize("input_img, preservation_rate, expected_output", [

--- a/tests/test_pooling_image.py
+++ b/tests/test_pooling_image.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from sharpedge.pooling_image import pooling_image
+from sharpedge import pooling_image
 
 # Valid cases: Testing pooling behavior with different pooling functions
 @pytest.mark.parametrize("img, window_size, pooling_method, expected", [

--- a/tests/test_reposition_image.py
+++ b/tests/test_reposition_image.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import warnings
-from sharpedge.reposition_image import reposition_image
+from sharpedge import reposition_image
 
 # Defining fixture for the test image
 @pytest.fixture

--- a/tests/test_seam_carving.py
+++ b/tests/test_seam_carving.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pytest
 import matplotlib.pyplot as plt
-from sharpedge.seam_carving import seam_carve
+from sharpedge import seam_carve
 
 test_image_dir = os.path.join(os.path.dirname(__file__), "test_image")
 


### PR DESCRIPTION
Add imports in __init__.py:


    from sharpedge.reposition_image import reposition_image
    from sharpedge.frame_image import frame_image
    from sharpedge.modulate_image import modulate_image
    from sharpedge.pooling_image import pooling_image
    from sharpedge.pca_compression import pca_compression
    from sharpedge.seam_carving import seam_carve


So that when someone imports them later, they can do so by using, e.g.:

    from sharpedge import reposition_image
    from sharpedge import frame_image

> **Note:** Sorry that I added a bunch of line breaks in `modulate_image.py`'s docstrings for no reason. Tiffany and I were trying things out to figure out the double colons issue in our API references during lab, but I forgot to exclude the changes in my commit. I'll address that in my future PR.