### PR TITLE
`reposition_image()` amendments

### DIFF
--- a/src/sharpedge/reposition_image.py
+++ b/src/sharpedge/reposition_image.py
@@ -2,6 +2,40 @@ import numpy as np
 import warnings
 from sharpedge._utils.utility import Utility
 
+
+def _flip_image(img, flip):
+    """Flips the image based on the specified flip parameter.
+    Private function to be invoked by reposition_image()"""
+    if flip == "horizontal":
+        return np.fliplr(img)
+    elif flip == "vertical":
+        return np.flipud(img)
+    elif flip == "both":
+        return np.fliplr(np.flipud(img))
+    return img
+
+def _rotate_image(img, rotate):
+    """Rotates the image based on the specified rotate parameter.
+    Private function to be invoked by reposition_image()"""
+    if rotate == "left":
+        return np.rot90(img, k=1)
+    elif rotate == "right":
+        return np.rot90(img, k=-1)
+    elif rotate == "down":
+        return np.rot90(img, k=2)
+    return img
+
+def _shift_image_x(img, shift_x):
+    """Shifts the image along the x-axis.
+    Private function to be invoked by reposition_image()"""
+    return np.roll(img, shift_x, axis=1)
+
+def _shift_image_y(img, shift_y):
+    """Shifts the image along the y-axis.
+    Private function to be invoked by reposition_image()"""
+    return np.roll(img, shift_y, axis=0)
+
+
 def reposition_image(img, flip='none', rotate='up', shift_x=0, shift_y=0):
     """
     Flip, rotate, and shift an image based on the specified requested action.
@@ -66,52 +100,39 @@ def reposition_image(img, flip='none', rotate='up', shift_x=0, shift_y=0):
     # Input validation
     Utility._input_checker(img)
 
-    # Validate flip
+    # Validate parameters
     valid_flips = ["none", "horizontal", "vertical", "both"]
     if flip not in valid_flips:
         raise ValueError("flip must be one of 'none', 'horizontal', 'vertical', or 'both'.")
 
-    # Validate rotate
     valid_rotations = ["up", "left", "right", "down"]
     if rotate not in valid_rotations:
         raise ValueError("rotate must be one of 'up', 'left', 'right', or 'down'.")
 
-    # Validate shift_x and shift_y
     if not isinstance(shift_x, int):
         raise TypeError("shift_x must be an integer.")
     if not isinstance(shift_y, int):
         raise TypeError("shift_y must be an integer.")
 
-    # Check if the image is 2D or 3D
+    # Check image dimensions
     if len(img.shape) == 2:
-        img_height, img_width = img.shape  # Grayscale image (2D)
+        img_height, img_width = img.shape
     elif len(img.shape) == 3:
-        img_height, img_width, _ = img.shape  # RGB image (3D)
+        img_height, img_width, _ = img.shape
 
-    # Check if shift values are larger than image dimensions and issue a warning if necessary
+    # Issue warnings for large shifts
     if shift_x >= img_width or shift_y >= img_height:
         warnings.warn(f"Shift values ({shift_x}, {shift_y}) are larger than the image dimensions.", UserWarning)
 
-    # Perform flipping
-    if flip == "horizontal":
-        img = np.fliplr(img)
-    elif flip == "vertical":
-        img = np.flipud(img)
-    elif flip == "both":
-        img = np.fliplr(np.flipud(img))
-
-    # Perform rotation
-    if rotate == "left":
-        img = np.rot90(img, k=1)
-    elif rotate == "right":
-        img = np.rot90(img, k=-1)
-    elif rotate == "down":
-        img = np.rot90(img, k=2)
-
-    # Perform shifting
-    img = np.roll(img, shift_x, axis=1)  # Shift along x-axis
-    img = np.roll(img, shift_y, axis=0)  # Shift along y-axis
+    # Apply transformations
+    img = _flip_image(img, flip)
+    img = _rotate_image(img, rotate)
+    img = _shift_image_x(img, shift_x)
+    img = _shift_image_y(img, shift_y)
 
     return img
+
+
+
 
 

--- a/src/sharpedge/reposition_image.py
+++ b/src/sharpedge/reposition_image.py
@@ -117,7 +117,7 @@ def reposition_image(img, flip='none', rotate='up', shift_x=0, shift_y=0):
     # Check image dimensions
     if len(img.shape) == 2:
         img_height, img_width = img.shape
-    elif len(img.shape) == 3:
+    else:
         img_height, img_width, _ = img.shape
 
     # Issue warnings for large shifts

--- a/tests/test_reposition_image.py
+++ b/tests/test_reposition_image.py
@@ -35,22 +35,28 @@ def test_valid_inputs(img, flip, rotate, shift_x, shift_y, expected):
 @pytest.mark.filterwarnings("ignore::UserWarning")  # Ignore specific warning in tests
 def test_edge_cases(flip, rotate, shift_x, shift_y):
     img = np.array([[255]])
-    # Call the reposition_image function
     result = reposition_image(img, flip=flip, rotate=rotate, shift_x=shift_x, shift_y=shift_y)
 
 # Test for 3D image (RGB image)
 def test_rgb_image():
-    # Simulate an RGB image (3D array)
-    rgb_img = np.array([[[255, 0, 0], [0, 255, 0]],  # Red and Green pixels
-                        [[0, 0, 255], [255, 255, 0]]])  # Blue and Yellow pixels
-
-    # Test the reposition_image function with this 3D image
+    rgb_img = np.array([[[255, 0, 0], [0, 255, 0]], [[0, 0, 255], [255, 255, 0]]])
     result = reposition_image(rgb_img, flip='none', rotate='up', shift_x=0, shift_y=0)
-    
-    # Ensure the result is the same as the original (since no transformation is applied)
     assert np.array_equal(result, rgb_img), "RGB image was not processed correctly"
 
-# Test erroneous cases 
+# Test for unique shape images (very tall or very wide)
+def test_unique_shape_images():
+    tall_img = np.arange(100).reshape(100, 1)  # 1 pixel wide, 100 pixels tall
+    wide_img = np.arange(100).reshape(1, 100)  # 100 pixels wide, 1 pixel tall
+    
+    result_tall = reposition_image(tall_img, flip='vertical', rotate='up', shift_x=0, shift_y=0)
+    expected_tall = np.flipud(tall_img)  # Vertical flip expected
+    assert np.array_equal(result_tall, expected_tall), "Tall image was not processed correctly"
+    
+    result_wide = reposition_image(wide_img, flip='horizontal', rotate='up', shift_x=0, shift_y=0)
+    expected_wide = np.fliplr(wide_img)  # Horizontal flip expected
+    assert np.array_equal(result_wide, expected_wide), "Wide image was not processed correctly"
+
+# Test erroneous cases
 def test_invalid_flip():
     img = np.array([[1, 2], [3, 4]])
     with pytest.raises(ValueError, match="flip must be one of 'none', 'horizontal', 'vertical', or 'both'."):


### PR DESCRIPTION
- In accordance to the TA's feedback I have created intermediary functions to be invoked by `reposition_image()` 
- In accordance to Shannon's peer review I have added edge cases for image sizes of 100x1 and 1x100
- As seen below there is still full coverage for the test

<img width="745" alt="image" src="https://github.com/user-attachments/assets/e489da49-d462-4685-a0f9-a4e7c53d828d" />
